### PR TITLE
Bump rxjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "react-scripts": "^5.0.1",
     "requestidlecallback-polyfill": "^1.0.2",
     "rimraf": "^3.0.2",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "semver": "^7.3.4",
     "slugify": "^1.6.5",
     "storybook": "^7.0.0-beta.35",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
     "prop-types": "^15.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "tss-react": "^4.0.0"
   },
   "publishConfig": {

--- a/packages/text-indexing/package.json
+++ b/packages/text-indexing/package.json
@@ -52,7 +52,7 @@
     "mobx-state-tree": "^5.0.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "private": true
 }

--- a/plugins/alignments/package.json
+++ b/plugins/alignments/package.json
@@ -56,7 +56,7 @@
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "tss-react": "^4.0.0"
   },
   "publishConfig": {

--- a/plugins/arc/package.json
+++ b/plugins/arc/package.json
@@ -49,7 +49,7 @@
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "private": true,
   "distModule": "esm/index.js",

--- a/plugins/authentication/package.json
+++ b/plugins/authentication/package.json
@@ -49,7 +49,7 @@
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/bed/package.json
+++ b/plugins/bed/package.json
@@ -48,7 +48,7 @@
     "mobx": "^6.0.0",
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/comparative-adapters/package.json
+++ b/plugins/comparative-adapters/package.json
@@ -51,7 +51,7 @@
     "prop-types": "^15.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "private": true,
   "distModule": "esm/index.js",

--- a/plugins/config/package.json
+++ b/plugins/config/package.json
@@ -48,7 +48,7 @@
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "tss-react": "^4.0.0"
   },
   "publishConfig": {

--- a/plugins/dotplot-view/package.json
+++ b/plugins/dotplot-view/package.json
@@ -54,7 +54,7 @@
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "tss-react": "^4.0.0"
   },
   "private": true,

--- a/plugins/gccontent/package.json
+++ b/plugins/gccontent/package.json
@@ -46,7 +46,7 @@
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/gff3/package.json
+++ b/plugins/gff3/package.json
@@ -48,7 +48,7 @@
     "@mui/material": "^5.0.0",
     "mobx": "^6.0.0",
     "mobx-state-tree": "^5.0.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/gtf/package.json
+++ b/plugins/gtf/package.json
@@ -49,7 +49,7 @@
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/hic/package.json
+++ b/plugins/hic/package.json
@@ -48,7 +48,7 @@
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "private": true,
   "distModule": "esm/index.js",

--- a/plugins/legacy-jbrowse/package.json
+++ b/plugins/legacy-jbrowse/package.json
@@ -48,7 +48,7 @@
     "mobx": "^6.0.0",
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/linear-comparative-view/package.json
+++ b/plugins/linear-comparative-view/package.json
@@ -54,7 +54,7 @@
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "tss-react": "^4.0.0"
   },
   "private": true,

--- a/plugins/rdf/package.json
+++ b/plugins/rdf/package.json
@@ -44,7 +44,7 @@
     "mobx": "^6.0.0",
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "private": true,
   "distModule": "esm/index.js",

--- a/plugins/sequence/package.json
+++ b/plugins/sequence/package.json
@@ -50,7 +50,7 @@
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
-    "rxjs": "^7.0.0"
+    "rxjs": "^7.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/plugins/spreadsheet-view/package.json
+++ b/plugins/spreadsheet-view/package.json
@@ -52,7 +52,7 @@
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "tss-react": "^4.0.0"
   },
   "private": true,

--- a/plugins/variants/package.json
+++ b/plugins/variants/package.json
@@ -55,7 +55,7 @@
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "tss-react": "^4.0.0"
   },
   "publishConfig": {

--- a/plugins/wiggle/package.json
+++ b/plugins/wiggle/package.json
@@ -60,7 +60,7 @@
     "mobx-react": "^7.0.0",
     "mobx-state-tree": "^5.0.0",
     "react": ">=16.8.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "tss-react": "^4.0.0"
   },
   "publishConfig": {

--- a/products/jbrowse-desktop/package.json
+++ b/products/jbrowse-desktop/package.json
@@ -93,7 +93,7 @@
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-error-boundary": "^3.0.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "sanitize-filename": "^1.6.3",
     "serialize-error": "^8.0.0",
     "timeago.js": "^4.0.2",

--- a/products/jbrowse-react-circular-genome-view/package.json
+++ b/products/jbrowse-react-circular-genome-view/package.json
@@ -56,7 +56,7 @@
     "mobx-react": "^7.5.0",
     "mobx-state-tree": "^5.0.0",
     "prop-types": "^15.0.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "tss-react": "^4.4.1"
   },
   "peerDependencies": {

--- a/products/jbrowse-react-linear-genome-view/package.json
+++ b/products/jbrowse-react-linear-genome-view/package.json
@@ -72,7 +72,7 @@
     "mobx-react": "^7.5.0",
     "mobx-state-tree": "^5.0.0",
     "prop-types": "^15.0.0",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "serialize-error": "^8.0.0",
     "tss-react": "^4.4.1"
   },

--- a/products/jbrowse-web/package.json
+++ b/products/jbrowse-web/package.json
@@ -66,7 +66,7 @@
     "react-dom": "^17.0.0",
     "react-error-boundary": "^3.0.0",
     "requestidlecallback-polyfill": "^1.0.2",
-    "rxjs": "^7.0.0",
+    "rxjs": "^7.8.0",
     "serialize-error": "^8.0.0",
     "shortid": "^2.2.15",
     "skmeans": "^0.11.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8414,11 +8414,6 @@ dateformat@^3.0.0:
   resolved "https://registry.npmmirror.com/dateformat/-/dateformat-3.0.3.tgz"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
-debounce@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmmirror.com/debounce/-/debounce-1.2.1.tgz"
-  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
-
 debug@2.6.9, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.npmmirror.com/debug/-/debug-2.6.9.tgz"
@@ -11424,6 +11419,11 @@ is-absolute-url@^3.0.0:
   version "3.0.3"
   resolved "https://registry.npmmirror.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz"
   integrity sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==
+
+is-any-array@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-any-array/-/is-any-array-2.0.0.tgz#e71bc13741537c06afac03c07885967ef56d8742"
+  integrity sha512-WdPV58rT3aOWXvvyuBydnCq4S2BM1Yz8shKxlEpk/6x+GX202XRvXOycEFtNgnHVLoc46hpexPFx8Pz1/sMS0w==
 
 is-arguments@^1.0.4, is-arguments@^1.1.1:
   version "1.1.1"
@@ -16866,31 +16866,17 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-run-queue@^1.0.0, run-queue@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmmirror.com/run-queue/-/run-queue-1.0.3.tgz"
-  integrity sha512-ntymy489o0/QQplUDnpYAYUsO50K9SBrIVaKCWDOJzYJts0f9WH9RFJkyagebkw5+y1oi00R7ynNW/d12GBumg==
-  dependencies:
-    aproba "^1.1.1"
-
-rxjs@^6.0.0, rxjs@^6.5.2:
-  version "6.6.7"
-  resolved "https://registry.npmmirror.com/rxjs/-/rxjs-6.6.7.tgz"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^7.0.0, rxjs@^7.5.4, rxjs@^7.5.5:
-  version "7.6.0"
-  resolved "https://registry.npmmirror.com/rxjs/-/rxjs-7.6.0.tgz"
-  integrity sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==
-  dependencies:
-    tslib "^2.1.0"
-
-rxjs@^7.5.2:
+rxjs@^7.5.2, rxjs@^7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
   integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
+  dependencies:
+    tslib "^2.1.0"
+
+rxjs@^7.5.5:
+  version "7.6.0"
+  resolved "https://registry.npmmirror.com/rxjs/-/rxjs-7.6.0.tgz"
+  integrity sha512-DDa7d8TFNUalGC9VqXvQ1euWNN7sc63TrUCuM9J998+ViviahMIjKSOU7rfcgFOF+FCD71BhDRv4hrFz+ImDLQ==
   dependencies:
     tslib "^2.1.0"
 


### PR DESCRIPTION
this forces the lock file onto rxjs to 7.8, there was a mix of 7.6 and 7.8 in the code, this should fix the build error

technically, it is a bit fragile that we require the exact version numbers to match like this, and we could try to work on that, but hope this helps